### PR TITLE
Support for functions with multiple return values (#31)

### DIFF
--- a/src/go-virtual-machine-main/tests/array.test.ts
+++ b/src/go-virtual-machine-main/tests/array.test.ts
@@ -11,6 +11,25 @@ describe('Array Type Checking', () => {
     )
   })
 
+  test('Array literal with less elements than in the type should still pass.', () => {
+    const code =
+    `var a [3]int = [3]int{1}
+    fmt.Println(a)`
+    expect(mainRunner(code).output).toEqual('[1 0 0]\n')
+  })
+
+  test('Array literal should ignore newline between elements being declared.', () => {
+    // note: does not ignore newline between elements and comma/close semi-colon,
+    // it would result in compilation error even in the actual language
+    const code =
+    `	var a [3]int = [3]int{
+    1,
+		2,
+		3}
+		fmt.Println(a)`
+    expect(mainRunner(code).output).toEqual('[1 2 3]\n')
+  })
+
   test('Array literal must have the same type as the declared type.', () => {
     expect(
       mainRunner('var a [3]int = [3]int{1, "wrong type", 3}').error?.message,

--- a/src/go-virtual-machine-main/tests/declaration.test.ts
+++ b/src/go-virtual-machine-main/tests/declaration.test.ts
@@ -14,6 +14,33 @@ describe('Variable Declaration Tests', () => {
     ).toEqual('13\n')
   })
 
+  test('Multiple constants in a line', () => {
+    expect(
+      mainRunner(
+        `const b, c int = 5, 12;
+        fmt.Println(b+c)`,
+      ).output,
+    ).toEqual('17\n')
+  })
+
+  test('Multiple variables in a line', () => {
+    expect(
+      mainRunner(
+        `var b, c int = 5, 12;
+        fmt.Println(b+c)`,
+      ).output,
+    ).toEqual('17\n')
+  })
+
+  test('Multiple variables in a line, shorthand version', () => {
+    expect(
+      mainRunner(
+        `b, c := 5, 12;
+        fmt.Println(b+c)`,
+      ).output,
+    ).toEqual('17\n')
+  })
+
   test('String Variables', () => {
     expect(
       mainRunner(

--- a/src/go-virtual-machine-main/tests/fmt.test.ts
+++ b/src/go-virtual-machine-main/tests/fmt.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest'
 import { mainRunner } from './utility'
 
 describe('fmt Type Checking', () => {
-  test('Selector on fmt should fail unless it is fmt.Println.', () => {
+  test('Selector on fmt should fail unless it is a supported fmt function.', () => {
     const code = `
     fmt.nonexistent("hi")
     `
@@ -13,12 +13,62 @@ describe('fmt Type Checking', () => {
   })
 })
 
-describe('fmt Execution', () => {
-  test('fmt.Println works', () => {
+describe('fmt.Println', () => {
+  test('fmt.Println handles string and boolean', () => {
     const code = `
     fmt.Println("Hello", "world", true, false)
     fmt.Println(1, 2, 3, 4)
     `
     expect(mainRunner(code).output).toEqual('Hello world true false\n1 2 3 4\n')
+  })
+
+  test('fmt.Println handles string and variable concatenation', () => {
+    const code = `
+    const name = "John Doe"
+    const age = 17
+    fmt.Println(name, "is", age, "years old")
+    fmt.Println(1, 2, 3, 4)
+    `
+    expect(mainRunner(code).output).toEqual('John Doe is 17 years old\n1 2 3 4\n')
+  })
+})
+
+describe('fmt.Print', () => {
+  test('boolean/integer printing', () => {
+    const code = `
+    fmt.Print(true, false)
+    fmt.Print(1, 2, 3, 4)
+    `
+    expect(mainRunner(code).output).toEqual('true false1 2 3 4')
+  })
+
+  // the argument before and after the string argument will coalesce with the string argument
+  test('fmt.Print works correctly when handling strings', () => {
+    const code = `
+    fmt.Print("Hello", false, "world", true, "false")
+    fmt.Print(1, 2, "3", 4)
+    `
+    expect(mainRunner(code).output).toEqual('Hellofalseworldtruefalse1 234')
+  })
+
+  test('fmt.Print handles string and variable concatenation', () => {
+    const code = `
+    const name = "John Doe"
+    const age = 17
+    fmt.Print(name, "is", age, "years old")
+    fmt.Print(1, 2, 3, 4)
+    `
+    expect(mainRunner(code).output).toEqual('John Doeis17years old1 2 3 4')
+  })
+
+})
+
+describe('fmt.Printf', () => {
+  test('fmt.Printf works the same as fmt.Print if only 1 string argument is supplied', () => {
+    const code = `
+    fmt.Printf("Hello World")
+    fmt.Printf("Byebye World")
+    `
+    expect(mainRunner(code).output).toEqual('Hello WorldByebye World')
   })
 })

--- a/src/go-virtual-machine-main/tests/function.test.ts
+++ b/src/go-virtual-machine-main/tests/function.test.ts
@@ -67,6 +67,57 @@ describe('Function Type Checking', () => {
       ).error?.message,
     ).toEqual('Too many return values\nhave (int64)\nwant ()')
   })
+
+  test('Function with more than 1 return value as argument for another function', () => {
+    const code = `
+    package main
+    import "fmt"
+    func u(x int) (y int, z int) {
+      return x, x;
+    }
+
+    func main() {
+      fmt.Print(u(6));
+    }
+    `
+    expect(runCode(code, 2048).output).toEqual('6 6')
+  })
+
+  test('Function with more than 1 return value to be assigned to variables', () => {
+    const code = `
+    package main
+    import "fmt"
+    func u(x int) (int, int) {
+      return x, x + 3;
+    }
+
+    func main() {
+      var a, b = u(8)
+      fmt.Println(a);
+      fmt.Println(b);
+    }
+    `
+    expect(runCode(code, 2048).output).toEqual('8\n11\n')
+  })
+
+  test('Nested function', () => {
+    const code = `
+    package main
+    import "fmt"
+    func f(x int) (y int) {
+      return x + 2;
+    }
+
+    func g(x int) (y int) {
+      return x + 5;
+    }
+
+    func main() {
+      fmt.Println(g(f(1)));
+    }
+    `
+    expect(runCode(code, 2048).output).toEqual('8\n')
+  })
 })
 
 describe('Function Execution tests', () => {

--- a/src/go-virtual-machine-main/virtual-machine/compiler/typing/packages.ts
+++ b/src/go-virtual-machine-main/virtual-machine/compiler/typing/packages.ts
@@ -60,6 +60,8 @@ export const builtinPackages = {
   fmt: (compiler: Compiler): Type => {
     const pkg = new PackageType('fmt', {
       Println: new FunctionType([], new ReturnType([]), true),
+      Print: new FunctionType([], new ReturnType([]), true),
+      Printf: new FunctionType([], new ReturnType([]), true),
     })
     compiler.type_environment.addType('fmt', pkg)
     const [frame_idx, var_idx] = compiler.context.env.declare_var('fmt')

--- a/src/go-virtual-machine-main/virtual-machine/index.ts
+++ b/src/go-virtual-machine-main/virtual-machine/index.ts
@@ -34,7 +34,7 @@ const runCode = (
     const message = (err as Error).message
     return {
       instructions: [],
-      output: 'Syntax Error!',
+      output: message,
       error: {
         message,
         type: 'parse',
@@ -56,7 +56,7 @@ const runCode = (
     const message = (err as CompileError).message
     return {
       instructions: [],
-      output: 'Compilation Error!',
+      output: message,
       error: {
         message,
         type: 'compile',
@@ -77,10 +77,10 @@ const runCode = (
     console.warn(result.errorMessage)
     return {
       instructions: [],
-      output: 'Runtime Error!',
+      output: result.errorMessage,
       error: {
         message: result.errorMessage,
-        type: 'runtime',
+        type: 'runtime', 
         details: result.errorMessage,
       },
       visualData: [],

--- a/src/go-virtual-machine-main/virtual-machine/parser/golang_parser.js
+++ b/src/go-virtual-machine-main/virtual-machine/parser/golang_parser.js
@@ -3913,7 +3913,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseLiteralValue() {
-    var s0, s1, s2, s3, s4, s5, s6;
+    var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
@@ -3924,39 +3924,40 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e28); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      s3 = peg$parseElementList();
-      if (s3 !== peg$FAILED) {
-        s4 = peg$parse_();
+      s2 = peg$parse_();
+      s3 = peg$currPos;
+      s4 = peg$parseElementList();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parse_();
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c20;
+          s6 = peg$c20;
           peg$currPos++;
         } else {
-          s5 = peg$FAILED;
+          s6 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$e33); }
         }
-        if (s5 === peg$FAILED) {
-          s5 = null;
+        if (s6 === peg$FAILED) {
+          s6 = null;
         }
-        s6 = peg$parse_();
-        s2 = s3;
+        s7 = peg$parse_();
+        s3 = s4;
       } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
+        peg$currPos = s3;
+        s3 = peg$FAILED;
       }
-      if (s2 === peg$FAILED) {
-        s2 = null;
+      if (s3 === peg$FAILED) {
+        s3 = null;
       }
       if (input.charCodeAt(peg$currPos) === 125) {
-        s3 = peg$c17;
+        s4 = peg$c17;
         peg$currPos++;
       } else {
-        s3 = peg$FAILED;
+        s4 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$e30); }
       }
-      if (s3 !== peg$FAILED) {
+      if (s4 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f39(s2);
+        s0 = peg$f39(s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;

--- a/src/go-virtual-machine-main/virtual-machine/parser/parser.peggy
+++ b/src/go-virtual-machine-main/virtual-machine/parser/parser.peggy
@@ -68,7 +68,7 @@ start = _ @SourceFile _
 
 //* =============== Whitespace ===============
 // By convention, _ is used to eat up whitespace.
-_ = ([ \t\r\n] / comment) *
+_ = ([ \t\r\n] / comment)*
 
 
 
@@ -286,7 +286,7 @@ QualifiedIdent = pkg:PackageName "." iden:identifier { return new QualifiedIdent
 //* Composite Literals
 CompositeLit = type:ArrayType _ value:LiteralValue { return new ArrayLiteralToken(location(), type, value) }
              / type:SliceType _ value:LiteralValue { return new SliceLiteralToken(location(), type, value) }
-LiteralValue = "{" elements:(@ElementList _ ","? _)? "}" { return new LiteralValueToken(location(), elements ?? []) }
+LiteralValue = "{" _ elements:(@ElementList _ ","? _)? "}" { return new LiteralValueToken(location(), elements ?? []) }
 ElementList  = head:KeyedElement rest:(_ "," _ @KeyedElement)* { return [head, ...rest] }
 // Ironically, KeyedElement will not support having a key for our implementation.
 KeyedElement = Element

--- a/src/go-virtual-machine-main/virtual-machine/parser/tokens/expressions.ts
+++ b/src/go-virtual-machine-main/virtual-machine/parser/tokens/expressions.ts
@@ -18,6 +18,7 @@ import {
   FunctionType,
   Int64Type,
   NoType,
+  ReturnType,
   SliceType,
   StringType,
   Type,
@@ -184,7 +185,9 @@ export class CallToken extends PrimaryExpressionModifierToken {
     }
 
     const argumentTypes = this.expressions.map((e) => e.compile(compiler))
-    this.pushInstruction(compiler, new CallInstruction(this.expressions.length))
+    this.pushInstruction(compiler, new CallInstruction(
+      argumentTypes[0] instanceof ReturnType ? argumentTypes[0].types.length : argumentTypes.length
+    ))
 
     // We only implement variadic functions that accept any number of any type of arguments,
     // so variadic functions do not require type checking.

--- a/src/go-virtual-machine-main/virtual-machine/parser/tokens/source_file.ts
+++ b/src/go-virtual-machine-main/virtual-machine/parser/tokens/source_file.ts
@@ -37,7 +37,7 @@ export class SourceFileToken extends Token {
     this.predeclareConstants(compiler)
 
     // Compile top level declarations.
-    for (const declaration of this.declarations || []) {
+    for (const declaration of this.declarations ?? []) {
       declaration.compile(compiler)
     }
 


### PR DESCRIPTION
* Implement fmt.Print()

* Update tests for println and print and implement trivial case for printf

* Fix array newline not ignored between { and first element

* Support for functions returning multiple values at once

* Remove duplicate test cases